### PR TITLE
Added Toolbar icon to bring up Bug Reporting guidelines at all times.

### DIFF
--- a/javascripts/discourse/api-initializers/before_bug_submit_dialog.js
+++ b/javascripts/discourse/api-initializers/before_bug_submit_dialog.js
@@ -1,3 +1,34 @@
 import { apiInitializer } from "discourse/lib/api";
+import BugReportInstructionsModal from "../components/bug-report-instructions-modal";
+import { getOwner } from "@ember/application";
+import I18n from "I18n";
 
-export default apiInitializer("0.11.1", api => {});
+export default apiInitializer("0.11.1", api => {
+    // Handle opening of the bug instructions modal from inside the d-editor
+    api.modifyClass("component:d-editor", {
+        pluginId: "discourse-bug-report-instructions",
+        actions: {
+            openBugInstructionsModal(toolbarEvent) {
+                const modal = getOwner(this).lookup("service:modal");
+                modal.show(BugReportInstructionsModal, { model: { 
+                    initialValue: false,
+                    isShown: true, 
+                } });
+            }
+        }
+    });
+    
+    // Add a button to the toolbar
+    api.onToolbarCreate(tb => {
+        const translation = I18n.t(themePrefix("toolbar.open_bug_instructions"))
+
+        tb.addButton({
+            id: 'bug-instructions-button',
+            group: 'extras',
+            icon: 'info-circle',
+            sendAction: (event) => tb.context.send('openBugInstructionsModal', event),
+            title: translation
+        })
+    });
+
+});

--- a/javascripts/discourse/components/bug-report-reply-proxy-button.gjs
+++ b/javascripts/discourse/components/bug-report-reply-proxy-button.gjs
@@ -103,6 +103,9 @@ export default class BugReportReplyProxyButton extends Component {
      */
     isWickedBugsCategory() {
         const topicController = getOwner(this).lookup("controller:topic");
+        if(!topicController || !topicController.model) {
+            return false;
+        }
         return topicController.model.category_id === this.wickedBugsCategoryId;
     }
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,6 @@
 en:
   theme_metadata:
     description: "This component shows a dialog before the user submits his bug reports."
+  toolbar:
+    open_bug_instructions: "Open Bug Reporting guidelines"
+


### PR DESCRIPTION
Added button in the composer toolbar that brings up the Bug Reporting guidelines.

![image](https://github.com/user-attachments/assets/e13d0c86-6a02-4cee-8768-20c9416a6fe1)
